### PR TITLE
Add WSDL-backed Fast MCP server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install deps
+        run: |
+          python -m pip install -r requirements.txt
+          python -m pip install pytest
+      - name: Tests
+        run: pytest -q

--- a/fast_mcp/__init__.py
+++ b/fast_mcp/__init__.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+from typing import Callable, Any
+from fastapi import FastAPI, Request as FastAPIRequest
+from fastapi.responses import JSONResponse
+
+
+class Request:
+    def __init__(self, json: dict):
+        self.json = json
+
+
+class Response:
+    def __init__(self, status: int = 200, json: Any | None = None):
+        self.status = status
+        self.json = json
+
+
+class MCPApp:
+    """Minimal MCP application wrapper using FastAPI."""
+
+    def __init__(self, title: str = "Fast MCP"):
+        self.app = FastAPI(title=title)
+        self.tools: dict[str, Callable[[Request], Response]] = {}
+
+    def tool(
+        self,
+        name: str,
+        description: str = "",
+        input_schema: str | None = None,
+        output_schema: str | None = None,
+    ) -> Callable[[Callable[[Request], Response]], Callable[[Request], Response]]:
+        def decorator(func: Callable[[Request], Response]):
+            self.tools[name] = func
+
+            async def endpoint(request: FastAPIRequest):
+                payload = await request.json()
+                resp = await func(Request(payload))
+                return JSONResponse(status_code=resp.status, content=resp.json)
+
+            endpoint.__name__ = name.replace("-", "_")
+            self.app.post(f"/invoke/{name}")(endpoint)
+            return func
+
+        return decorator

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi
+uvicorn
+zeep==4.*
+lxml
+requests
+httpx
+requests-mock

--- a/server.py
+++ b/server.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+WSDL-Search MCP – Dynamically exposes every SOAP operation in the
+given WSDL as an independent Fast-MCP tool.
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+import os
+import textwrap
+
+from fast_mcp import MCPApp, Request, Response
+from zeep import Client, helpers
+from zeep.exceptions import Fault
+
+from wsdl_utils import discover_operations, render_schema_md, coerce_inputs
+
+log = logging.getLogger("wsdl_search_mcp")
+log.setLevel(logging.INFO)
+log.addHandler(logging.StreamHandler())
+
+WSDL_URL_ENV = "WSDL_URL"
+EXEC_TIMEOUT = 5
+
+app = MCPApp(title="WSDL-Search MCP")
+
+
+def register_operation(op):
+    """Register a SOAP operation as a Fast-MCP tool."""
+
+    @app.tool(
+        name=op.full_name,
+        description=textwrap.dedent(
+            f"""
+            {op.doc or f"SOAP Operation **{op.operation}**."}
+            {render_schema_md(op)}
+            Input: JSON object where keys are parameter names shown above.
+            Output: JSON object converted from the SOAP response.
+            """
+        ).strip(),
+        input_schema="object",
+        output_schema="any",
+    )
+    async def _(req: Request) -> Response:
+        params: dict = req.json
+        try:
+            payload = coerce_inputs(op, params)
+        except ValueError as exc:
+            return Response(status=422, json={"error": str(exc)})
+
+        loop = asyncio.get_running_loop()
+        try:
+            result = await loop.run_in_executor(
+                None, functools.partial(op.callable, **payload)
+            )
+        except Fault as fault:
+            return Response(status=400, json={"fault": str(fault)})
+        except Exception as exc:
+            log.warning("soap-call-error %s: %s", op.full_name, exc)
+            return Response(status=502, json={"error": str(exc)})
+
+        return Response(json=helpers.serialize_object(result))
+
+
+def startup():
+    url = os.getenv(WSDL_URL_ENV)
+    if not url:
+        raise RuntimeError(f"{WSDL_URL_ENV} is not set")
+
+    log.info("Loading WSDL %s", url)
+    client = Client(url)
+
+    for op in discover_operations(client):
+        register_operation(op)
+        log.info("Registered tool %s", op.full_name)
+
+
+startup()

--- a/tests/test_call_success.py
+++ b/tests/test_call_success.py
@@ -1,0 +1,40 @@
+from collections import namedtuple
+import importlib
+from fastapi.testclient import TestClient
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import wsdl_utils
+
+OperationMeta = namedtuple(
+    "OperationMeta", "service port operation full_name doc params callable"
+)
+
+
+def test_call_success(monkeypatch):
+    def handler(**params):
+        return {"ok": params}
+
+    op = OperationMeta(
+        service="Svc",
+        port="Port",
+        operation="Op",
+        full_name="svc_port_op",
+        doc="doc",
+        params=[{"name": "x", "type": "int", "optional": False, "children": None}],
+        callable=handler,
+    )
+
+    def fake_discover(client):
+        return [op]
+
+    monkeypatch.setattr(wsdl_utils, "discover_operations", fake_discover)
+    import zeep
+    monkeypatch.setattr(zeep, "Client", lambda url: object())
+    monkeypatch.setenv("WSDL_URL", "dummy")
+    import server
+    importlib.reload(server)
+
+    client = TestClient(server.app.app)
+    resp = client.post("/invoke/svc_port_op", json={"x": 1})
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": {"x": 1}}

--- a/tests/test_fault.py
+++ b/tests/test_fault.py
@@ -1,0 +1,41 @@
+from collections import namedtuple
+import importlib
+from fastapi.testclient import TestClient
+from zeep.exceptions import Fault
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import wsdl_utils
+
+OperationMeta = namedtuple(
+    "OperationMeta", "service port operation full_name doc params callable"
+)
+
+
+def test_fault(monkeypatch):
+    def handler(**params):
+        raise Fault("boom")
+
+    op = OperationMeta(
+        service="Svc",
+        port="Port",
+        operation="Op",
+        full_name="svc_port_op",
+        doc="doc",
+        params=[{"name": "x", "type": "int", "optional": False, "children": None}],
+        callable=handler,
+    )
+
+    def fake_discover(client):
+        return [op]
+
+    monkeypatch.setattr(wsdl_utils, "discover_operations", fake_discover)
+    import zeep
+    monkeypatch.setattr(zeep, "Client", lambda url: object())
+    monkeypatch.setenv("WSDL_URL", "dummy")
+    import server
+    importlib.reload(server)
+
+    client = TestClient(server.app.app)
+    resp = client.post("/invoke/svc_port_op", json={"x": 1})
+    assert resp.status_code == 400
+    assert resp.json() == {"fault": "boom"}

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,40 @@
+from collections import namedtuple
+import importlib
+from fastapi.testclient import TestClient
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import wsdl_utils
+
+OperationMeta = namedtuple(
+    "OperationMeta", "service port operation full_name doc params callable"
+)
+
+
+def test_validation(monkeypatch):
+    def handler(**params):
+        return params
+
+    op = OperationMeta(
+        service="Svc",
+        port="Port",
+        operation="Op",
+        full_name="svc_port_op",
+        doc="doc",
+        params=[{"name": "x", "type": "int", "optional": False, "children": None}],
+        callable=handler,
+    )
+
+    def fake_discover(client):
+        return [op]
+
+    monkeypatch.setattr(wsdl_utils, "discover_operations", fake_discover)
+    import zeep
+    monkeypatch.setattr(zeep, "Client", lambda url: object())
+    monkeypatch.setenv("WSDL_URL", "dummy")
+    import server
+    importlib.reload(server)
+
+    client = TestClient(server.app.app)
+    resp = client.post("/invoke/svc_port_op", json={})
+    assert resp.status_code == 422
+    assert resp.json() == {"error": "missing required field 'x'"}

--- a/tests/test_wsdl_discovery.py
+++ b/tests/test_wsdl_discovery.py
@@ -1,0 +1,33 @@
+from collections import namedtuple
+import importlib
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import wsdl_utils
+
+OperationMeta = namedtuple(
+    "OperationMeta", "service port operation full_name doc params callable"
+)
+
+
+def test_registration(monkeypatch):
+    op = OperationMeta(
+        service="Svc",
+        port="Port",
+        operation="Op",
+        full_name="svc_port_op",
+        doc="doc",
+        params=[],
+        callable=lambda **kw: None,
+    )
+
+    def fake_discover(client):
+        return [op]
+
+    monkeypatch.setattr(wsdl_utils, "discover_operations", fake_discover)
+    import zeep
+    monkeypatch.setattr(zeep, "Client", lambda url: object())
+    monkeypatch.setenv("WSDL_URL", "dummy")
+    import server
+    importlib.reload(server)
+
+    assert "svc_port_op" in server.app.tools

--- a/wsdl_utils.py
+++ b/wsdl_utils.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+import textwrap
+from collections import namedtuple
+from typing import Any
+from zeep import helpers, xsd
+
+OperationMeta = namedtuple(
+    "OperationMeta",
+    "service port operation full_name doc params callable",
+)
+
+
+def discover_operations(client) -> list[OperationMeta]:
+    meta: list[OperationMeta] = []
+    for service in client.wsdl.services.values():
+        for port in service.ports.values():
+            binding = port.binding
+            for op_name, op_obj in binding._operations.items():
+                signature = op_obj.input.body.type
+                params = _flatten_signature(signature)
+                full = f"{service.name}_{port.name}_{op_name}".lower()
+                meta.append(
+                    OperationMeta(
+                        service=service.name,
+                        port=port.name,
+                        operation=op_name,
+                        full_name=full,
+                        doc=op_obj.operation.input.documentation,
+                        params=params,
+                        callable=getattr(client.service, op_name),
+                    )
+                )
+    return meta
+
+
+def render_schema_md(op: OperationMeta) -> str:
+    lines = ["Parameters:"]
+    for p in op.params:
+        annot = f"{p['type']}{' (optional)' if p['optional'] else ''}"
+        lines.append(f"  • **{p['name']}** – {annot}")
+        if p.get("children"):
+            for child in p["children"]:
+                lines.append(f"      • {child['name']} ({child['type']})")
+    return textwrap.indent("\n".join(lines), "")
+
+
+def _flatten_signature(sig) -> list[dict]:
+    params = []
+    for element in sig.elements:
+        children = []
+        if isinstance(element.type, xsd.ComplexType):
+            for sub in element.type.elements:
+                children.append(
+                    dict(
+                        name=sub.name,
+                        type=sub.type.name,
+                        optional=sub.min_occurs == 0,
+                    )
+                )
+        params.append(
+            dict(
+                name=element.name,
+                type=element.type.name,
+                optional=element.min_occurs == 0,
+                children=children or None,
+            )
+        )
+    return params
+
+
+def coerce_inputs(op: OperationMeta, payload: dict):
+    result = {}
+    for p in op.params:
+        name = p["name"]
+        if name not in payload:
+            if p["optional"]:
+                continue
+            raise ValueError(f"missing required field '{name}'")
+        result[name] = payload[name]
+    return result


### PR DESCRIPTION
## Summary
- implement a small Fast MCP framework
- expose WSDL operations as tools via `server.py`
- helper functions in `wsdl_utils.py`
- unit tests cover discovery, happy path, faults and validation
- CI workflow runs pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685518b9a0d4832ca7075f787aa57e76